### PR TITLE
Updated raw Github URLs to scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Enter your e-mail address and password to login to your own RSS server. You can 
 
 ![006](https://raw.github.com/maloninc/fever-on-heroku-bootstrap/master/images/006.png)
 
-    ./refresh.sh http://<YOUR-HEROKU-APP>/ <FEVER-SERIAL> <DB_SERVER_NAME> <DB_NAME> <USERNAME> <PASSWORD>
+    ./refresh.sh http://<YOUR-HEROKU-APP>/ <FEVER-ACTIVATION-KEY> <DB_SERVER_NAME> <DB_NAME> <USERNAME> <PASSWORD>
 
 Becuase Heroku will restart the instance every day, causing Fever lock you out, refresh.sh script re-activate your Fever automatically.
 Also MySQL addon ClearDB which your Fever used has a limitation of 5MB storage, as a reslution purge.php script which is called in refresh.sh removes old data which are 2+ days before.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ How
 =========================
 #### Step 1: Run bootstrap script.
 
-    curl -O https://raw.github.com/maloninc/fever-on-heroku-bootstrap/master/bootstrap.sh; sh bootstrap.sh
+    sh -c "$(curl -fsSL https://raw.githubusercontent.com/maloninc/fever-on-heroku-bootstrap/master/bootstrap.sh)"
 
 or
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -56,7 +56,7 @@ echo "    heroku addons:open scheduler"
 echo ""
 echo "Then enter the following command to the command field, and configure it as per-10-miniutes job."
 echo ""
-echo "    ./refresh.sh http://<YOUR-HEROKU-APP>/ <FEVER-SERIAL> <DB_SERVER_NAME> <DB_NAME> <USERNAME> <PASSWORD>"
+echo "    ./refresh.sh http://<YOUR-HEROKU-APP>/ <FEVER-ACTIVATION-KEY> <DB_SERVER_NAME> <DB_NAME> <USERNAME> <PASSWORD>"
 echo ""
 echo ""
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,8 +14,8 @@ unzip -q fever.zip -d . && rm fever.zip
 echo '<meta http-equiv="refresh" content="3;URL=/fever/boot.php">' > index.php
 
 # Download maintenance scripts
-curl -s -O https://raw.github.com/maloninc/fever-on-heroku-bootstrap/master/purge.php
-curl -s -O https://raw.github.com/maloninc/fever-on-heroku-bootstrap/master/refresh.sh
+curl -s -O https://raw.githubusercontent.com/maloninc/fever-on-heroku-bootstrap/master/purge.php
+curl -s -O https://raw.githubusercontent.com/maloninc/fever-on-heroku-bootstrap/master/refresh.sh
 
 # First commit
 git add -A .


### PR DESCRIPTION
I updated the URLs to the scripts, referred to the Fever serial as the Fever activation key to clarify things (I was confused for a bit when I first read it) and changed the instructions to run the bootstrap script without downloading it like the homebrew instructions do.
